### PR TITLE
Getting user input for services from service json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.DS_Store
-/venv
+*/venv
 *__pycache__*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,16 @@ by the peers, someone may create a pull request that addresses the issue.
 
 Anyone may participate in peer review which is expressed by comments in the
 pull request or issue. Typically reviewers will review the code for obvious errors,
-and discuss the merits of a particular issue and how it should be resolved. Project
-maintainers take into account the peer review when determining if there is consensus
+and discuss the merits of a particular issue and how it should be resolved. 
+
+Peer reviewers can simply comment with one of these to express the level of review they gave:
+
+- Concept ACK - agree with the concept but haven't reviewed the changes
+- utACK (Untested ACK) - agree with the changes and reviewed them but didn't test
+- Tested ACK - agree with changes, reviewed and tested
+- NACK - Disagree with changes, please provide reasoning
+
+Project maintainers take into account the peer review when determining if there is consensus
 to merge a pull request.
 
 ## Code Commits

--- a/services/filerun/service.json
+++ b/services/filerun/service.json
@@ -1,0 +1,7 @@
+{
+	"name": "FileRun File Browser",
+	"maintainer": "count-null",
+	"description": "Manage your files.",
+	"links": ["https://filerun.com"],
+	"var_fields": []
+}

--- a/services/minecraft_server/service.json
+++ b/services/minecraft_server/service.json
@@ -1,6 +1,10 @@
 {
-"name": "Minecfart Server",
-"author": "count-null",
-"description": "Run a minecraft server",
-"links": ["https://github.com/itzg/docker-minecraft-server"]
+	"name": "Minecfart Server",
+	"maintainer": "count-null",
+	"description": "Run a minecraft server.",
+	"links": ["https://github.com/itzg/docker-minecraft-server"],
+	"var_fields": [
+		{"name": "Server Type", "field": "select", "value": "SPIGOT", "options": ["SPIGOT","FORGE","PAPER","TUINITY","MAGMA","MOHIST","CATSERVER","SPONGEVANILLA","FABRIC"]},
+		{"name": "Minecraft Version", "field": "select", "value": "LATEST", "options": ["LATEST", "SNAPSHOT", "1.16.3", "1.16.2", "1.16.1", "1.16"]}
+	]
 }

--- a/services/nextcloud/service.json
+++ b/services/nextcloud/service.json
@@ -1,0 +1,7 @@
+{
+	"name": "Nextcloud Office Suite",
+	"maintainer": "count-null",
+	"description": "The self-hosted productivity platform that keeps you in control",
+	"links": ["https://nextcloud.com"],
+	"var_fields": []
+}

--- a/services/plex/service.json
+++ b/services/plex/service.json
@@ -1,0 +1,12 @@
+{
+	"name": "Plex Media Server",
+	"maintainer": "count-null",
+	"description": "Plex brings together all the media that matters to you.",
+	"links": ["https://www.plex.tv/"],
+	"var_fields": [
+		{"name": "TV Shows Directory", "field": "input", "value": "/mnt/usb/files/Series"},
+		{"name": "Movies Directory", "field": "input", "value": "/mnt/usb/files/Movies"},
+		{"name": "Music Directory", "field": "input", "value": "/mnt/usb/files/Music"},
+		{"name": "Photos Directory", "field": "input", "value": "/mnt/usb/files/Photos"}
+	]
+}

--- a/services/transmission/service.json
+++ b/services/transmission/service.json
@@ -1,0 +1,10 @@
+{
+	"name": "Transmission Torrent Client",
+	"maintainer": "count-null",
+	"description": "Download and seed torrents directly from your device.",
+	"links": ["https://github.com/Secretmapper/combustion"],
+	"var_fields": [
+		{"name": "In Progress Downloads", "field": "input", "value": "/mnt/usb/files/torrents/incomplete"},
+		{"name": "Completed Downloads", "field": "input", "value": "/mnt/usb/files/torrents/complete"}
+	]
+}


### PR DESCRIPTION
Addresses #35

Added a services.json to each service. The idea is to store information to show on the "settings" or "configure" page for each service. 

Maybe this isn't the best format for it, please discuss. 

the `var_fields` defines what form inputs to render. It also stores the values selected. 
We need some way to get these values into the docker-compose file.

One way is to have a shell script in the service folder called `start.sh`. That script will parse out the variables in service.json and pass them as env vars to a docker-compose command. Then when we enable the service, we call the script instead of doing `docker-compose up`.

Another way to do this is to dynamically generate the docker-compose file using shell scripts. We divide the current file up into fragments and when the user saves their configuration, we run a script called `assemble-compose.sh` which parses the variables in service.json and assembles the yml fragments into a new docker-compose.yml with the variables included. This way, we can continue to call `docker-compose up` in all cases. 

There's probably a smarter way of doing this. 